### PR TITLE
feat: support parent maps in traverse

### DIFF
--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -3,19 +3,23 @@ import type {ParsedDependency, DependencyType} from './types.js';
 export interface Visitor {
   dependency?: (
     node: ParsedDependency,
-    parent: ParsedDependency | null
+    parent: ParsedDependency | null,
+    parentMap: WeakMap<ParsedDependency, ParsedDependency>
   ) => unknown;
   devDependency?: (
     node: ParsedDependency,
-    parent: ParsedDependency | null
+    parent: ParsedDependency | null,
+    parentMap: WeakMap<ParsedDependency, ParsedDependency>
   ) => unknown;
   peerDependency?: (
     node: ParsedDependency,
-    parent: ParsedDependency | null
+    parent: ParsedDependency | null,
+    parentMap: WeakMap<ParsedDependency, ParsedDependency>
   ) => unknown;
   optionalDependency?: (
     node: ParsedDependency,
-    parent: ParsedDependency | null
+    parent: ParsedDependency | null,
+    parentMap: WeakMap<ParsedDependency, ParsedDependency>
   ) => unknown;
 }
 
@@ -26,14 +30,24 @@ const visitorKeys: Array<[keyof Visitor, DependencyType]> = [
   ['optionalDependency', 'optionalDependencies']
 ];
 
-export function traverse(node: ParsedDependency, visitor: Visitor): void {
+function traverseInternal(
+  node: ParsedDependency,
+  visitor: Visitor,
+  parentMap: WeakMap<ParsedDependency, ParsedDependency>
+): void {
   for (const [visitorKey, nodeKey] of visitorKeys) {
     if (visitor[visitorKey]) {
       for (const dep of node[nodeKey]) {
-        if (visitor[visitorKey](dep, node) !== false) {
-          traverse(dep, visitor);
+        parentMap.set(dep, node);
+        if (visitor[visitorKey](dep, node, parentMap) !== false) {
+          traverseInternal(dep, visitor, parentMap);
         }
       }
     }
   }
+}
+
+export function traverse(node: ParsedDependency, visitor: Visitor): void {
+  const parentMap = new WeakMap<ParsedDependency, ParsedDependency>();
+  return traverseInternal(node, visitor, parentMap);
 }

--- a/test/traverse.test.ts
+++ b/test/traverse.test.ts
@@ -1,0 +1,75 @@
+import {describe, it, expect, vi} from 'vitest';
+import {traverse} from '../src/traverse.js';
+import type {ParsedDependency} from '../src/types.js';
+
+describe('traverse', () => {
+  it('should traverse dependencies correctly', () => {
+    const root: ParsedDependency = {
+      name: 'root',
+      version: '1.0.0',
+      dependencies: [
+        {
+          name: 'dep1',
+          version: '1.0.0',
+          dependencies: [],
+          devDependencies: [
+            {
+              name: 'dep1-devDep1',
+              version: '1.0.0',
+              dependencies: [],
+              devDependencies: [],
+              peerDependencies: [],
+              optionalDependencies: []
+            }
+          ],
+          peerDependencies: [],
+          optionalDependencies: []
+        }
+      ],
+      devDependencies: [
+        {
+          name: 'devDep1',
+          version: '1.0.0',
+          dependencies: [],
+          devDependencies: [],
+          peerDependencies: [],
+          optionalDependencies: []
+        }
+      ],
+      peerDependencies: [],
+      optionalDependencies: []
+    };
+
+    const visitDependency = vi.fn();
+    const visitDevDependency = vi.fn();
+
+    traverse(root, {
+      dependency: visitDependency,
+      devDependency: visitDevDependency
+    });
+
+    expect(visitDependency).toHaveBeenCalledTimes(1);
+    expect(visitDevDependency).toHaveBeenCalledTimes(2);
+
+    const visitedDependencies = visitDependency.mock.calls.map(
+      (call) => call[0].name
+    );
+    const visitedDevDependencies = visitDevDependency.mock.calls.map(
+      (call) => call[0].name
+    );
+
+    expect(visitedDependencies).toEqual(['dep1']);
+    expect(visitedDevDependencies).toEqual(['dep1-devDep1', 'devDep1']);
+
+    const parentOfDep1 = visitDependency.mock.calls[0][1];
+    expect(parentOfDep1.name).toBe('root');
+
+    const parentOfDep1DevDep1 = visitDevDependency.mock.calls[0][1];
+    expect(parentOfDep1DevDep1.name).toBe('dep1');
+
+    const parentMapOfDevDep1 = visitDevDependency.mock.calls[1][2];
+    expect(parentMapOfDevDep1.get(visitDevDependency.mock.calls[1][0])).toBe(
+      root
+    );
+  });
+});


### PR DESCRIPTION
The traverse function now provides a 3rd parameter, the parent map. This
is a `WeakMap` which links dependencies to their parent, allowing you to
walk up the path.
