### PR TITLE
fix: skip packge links in npm parsing

### DIFF
--- a/src/parsers/npm.ts
+++ b/src/parsers/npm.ts
@@ -18,10 +18,15 @@ interface NpmLockFilePackage {
   peerDependenciesMeta?: Record<string, NpmLockFilePeerDependencyMeta>;
 }
 
+interface NpmLockFilePackageLink {
+  resolved: string;
+  link: true;
+}
+
 interface NpmLockFileLike {
   name: string;
   version: string;
-  packages: Record<string, NpmLockFilePackage>;
+  packages: Record<string, NpmLockFilePackage | NpmLockFilePackageLink>;
 }
 
 export async function parseNpm(input: string): Promise<ParsedLockFile> {
@@ -50,13 +55,25 @@ export async function parseNpm(input: string): Promise<ParsedLockFile> {
   return parsed;
 }
 
-function processPackages(input: Record<string, NpmLockFilePackage>): {
+function isPackageLink(
+  pkg: NpmLockFilePackage | NpmLockFilePackageLink
+): pkg is NpmLockFilePackageLink {
+  return 'link' in pkg && pkg.link === true;
+}
+
+function processPackages(
+  input: Record<string, NpmLockFilePackage | NpmLockFilePackageLink>
+): {
   root: ParsedDependency;
   packages: ParsedDependency[];
 } {
   const packageMap: Record<string, ParsedDependency> = {};
 
   for (const [pkgKey, pkg] of Object.entries(input)) {
+    if (isPackageLink(pkg)) {
+      // for now at least, skip workspace packages
+      continue;
+    }
     const modulesIndex = pkgKey.lastIndexOf('node_modules/');
     let name = pkg.name;
     if (modulesIndex !== -1) {
@@ -73,6 +90,11 @@ function processPackages(input: Record<string, NpmLockFilePackage>): {
   }
 
   for (const [pkgKey, pkg] of Object.entries(input)) {
+    if (isPackageLink(pkg)) {
+      // for now at least, skip workspace packages
+      continue;
+    }
+
     const parsedPkg = packageMap[pkgKey];
 
     processDependencyMap(pkg, parsedPkg, packageMap, pkgKey);

--- a/test/parsers/__snapshots__/npm.test.ts.snap
+++ b/test/parsers/__snapshots__/npm.test.ts.snap
@@ -706,3 +706,18 @@ exports[`npm parser > parses a complex npm lock file 1`] = `
   "type": "npm",
 }
 `;
+
+exports[`npm parser > skips package links 1`] = `
+{
+  "packages": [],
+  "root": {
+    "dependencies": [],
+    "devDependencies": [],
+    "name": "example-project",
+    "optionalDependencies": [],
+    "peerDependencies": [],
+    "version": "1.0.0",
+  },
+  "type": "npm",
+}
+`;

--- a/test/parsers/npm.test.ts
+++ b/test/parsers/npm.test.ts
@@ -49,6 +49,29 @@ describe('npm parser', () => {
     );
   });
 
+  test('skips package links', async () => {
+    const input = JSON.stringify({
+      name: 'example-project',
+      version: '1.0.0',
+      lockfileVersion: 2,
+      packages: {
+        '': {
+          name: 'example-project',
+          version: '1.0.0',
+          dependencies: {
+            'example-workspace-package': '0.0.1'
+          }
+        },
+        'node_modules/example-workspace-package': {
+          resolved: 'packages/example-workspace-package',
+          link: true
+        }
+      }
+    });
+    const parsed = await parse(input, 'npm');
+    expect(parsed).toMatchSnapshot();
+  });
+
   test('parses a complex npm lock file', async () => {
     const input = await readFile(
       path.join(fixtureDir, 'package-lock.json'),


### PR DESCRIPTION
If you depend on a workspace package, the package entry is actually
`{resolved, link}` rather than a rich meta object.

This change skips them when computing the package list.
